### PR TITLE
Convert records to JSON API like dashcase when serializing

### DIFF
--- a/utils/models/BaseModel.php
+++ b/utils/models/BaseModel.php
@@ -489,11 +489,11 @@ class BaseModel {
     $parentIncludes = $this->get_sub_includes($includes);
 
     foreach ($this->get_linked_tables() as $key => $value) {
-      $tableName = str_replace('-id', '', $key);
+      $tableName = str_replace('_id', '', $key);
       if (array_key_exists($tableName, $parentIncludes)) {
         $linkModelData = new $value[0]($allData[$key]);
         unset($allData[$key]);
-        $jsonKey = str_replace('-id', '', $key);
+        $jsonKey = str_replace('_id', '', $key);
         $allData[$jsonKey] = $linkModelData->get_linked_data($parentIncludes[$tableName]);
       }
     }

--- a/utils/routes/BaseJsonGetAllRoute.php
+++ b/utils/routes/BaseJsonGetAllRoute.php
@@ -84,7 +84,7 @@ class BaseJsonGetAllRoute extends BaseJsonRoute {
 
     // add all of the data from each model in the collection
     $collection->each(function($model) use (&$data, $include) {
-      $data[] = $model->get_linked_data($include);
+      $data[] = $this->dashKeys($model->get_linked_data($include));
     });
 
     $res = JsonResHandler::render($data, 200);

--- a/utils/routes/BaseJsonGetOneRoute.php
+++ b/utils/routes/BaseJsonGetOneRoute.php
@@ -11,7 +11,8 @@ class BaseJsonGetOneRoute extends BaseJsonRoute {
 
     try {
       $model = new $class_name($search);
-      $res = JsonResHandler::render($model->get_linked_data($include), 200);
+      $data = $model->get_linked_data($include);
+      $res = JsonResHandler::render($this->dashKeys($data), 200);
     } catch (Exception $err) {
       $this->_handle_get_one_error($err);
     }

--- a/utils/routes/BaseJsonPatchRoute.php
+++ b/utils/routes/BaseJsonPatchRoute.php
@@ -26,7 +26,7 @@ class BaseJsonPatchRoute extends BaseJsonRoute {
 
     // save the model and render the new data for the user
     $model->save();
-    $res = JsonResHandler::render($model->get_user_friendly_data(), 200);
+    $res = JsonResHandler::render($this->dashKeys($model->get_user_friendly_data()), 200);
   }
 
   protected function _sanitize_operation_values($base_url = '', $operations = array()) {
@@ -94,7 +94,8 @@ class BaseJsonPatchRoute extends BaseJsonRoute {
 
   protected function _parse_field_from_operation_path($base_url = '', $path = '') {
     $base_url .= '/';
-    return str_replace($base_url, '', $path);
+    $field = str_replace($base_url, '', $path);
+    return str_replace('-', '_', $field);
   }
 
   protected function _get_model($identifier = null) {

--- a/utils/routes/BaseJsonPostRoute.php
+++ b/utils/routes/BaseJsonPostRoute.php
@@ -38,6 +38,8 @@ class BaseJsonPostRoute extends BaseJsonRoute {
   }
 
   public function create_new_model($data = array()) {
+    $data = $this->underscoreKeys($data);
+
     // ensure that all of the fields actually exist
     $this->_validate_data($data);
 
@@ -56,8 +58,7 @@ class BaseJsonPostRoute extends BaseJsonRoute {
 
     // save this new object and render the result
     $model->save();
-    $res = JsonResHandler::render($model->get_user_friendly_data(), 200);
+    $res = JsonResHandler::render($this->dashKeys($model->get_user_friendly_data()), 200);
   }
 
 }
-

--- a/utils/routes/BaseJsonRoute.php
+++ b/utils/routes/BaseJsonRoute.php
@@ -61,4 +61,29 @@ class BaseJsonRoute extends BaseRoute {
     return $identifier;
   }
 
+  public function dashKeys($array, $arrayHolder = array()) {
+    $dashArray = !empty($arrayHolder) ? $arrayHolder : array();
+    foreach ($array as $key => $val) {
+      $newKey = str_replace('_', '-', $key);
+      if (!is_array($val)) {
+        $dashArray[$newKey] = $val;
+      } else {
+        $dashArray[$newKey] = $this->dashKeys($val);
+      }
+    }
+    return $dashArray;
+  }
+
+  public function underscoreKeys($array, $arrayHolder = array()) {
+    $underscoreArray = !empty($arrayHolder) ? $arrayHolder : array();
+    foreach ($array as $key => $val) {
+      $newKey = str_replace('-', '_', $key);
+      if (!is_array($val)) {
+        $underscoreArray[$newKey] = $val;
+      } else {
+        $underscoreArray[$newKey] = $this->underscoreKeys($val);
+      }
+    }
+    return $underscoreArray;
+  }
 }


### PR DESCRIPTION
This will make it so our router framework serializes records in a JSON API like format and thus we do not need to make compromises in other parts of our stack (models and db tables) to conform with API conventions.


I'd like to have a conversation about if we think this is a good idea. I think this will improve the ergonomics of accessing model properties and writing sql queries. 