### PR TITLE
remove hardcoded 'id' values

### DIFF
--- a/utils/collections/BaseCollection.php
+++ b/utils/collections/BaseCollection.php
@@ -99,7 +99,8 @@ class BaseCollection {
     }
 
     // finally, fetch the results
-    $fields = array('id');
+    $primary_key = $this->_model_object->get_db_primary_key();
+    $fields = array($primary_key);
     if (is_integer($limit)) {
       $results = Database::get($this->_model_object->get_db_table(), $limit, $fields);
     } else {
@@ -115,7 +116,7 @@ class BaseCollection {
     }
 
     // first, pluck the id's from results
-    $ids = array_pluck('id', $results);
+    $ids = array_pluck($primary_key, $results);
 
     // finally, instantiate new models for each result that was fetched
     $class_name = $this->get_model_class();

--- a/utils/models/BaseModel.php
+++ b/utils/models/BaseModel.php
@@ -319,9 +319,10 @@ class BaseModel {
     $this->_update();
     if (count($this->_inactive_cleanup)) {
       foreach ($this->_inactive_cleanup as $key => $value) {
+        $primaryKey = $this->get_db_primary_key();
         $search = array(
-                    $value['identifier'] => $this->__get('id')
-                  );
+                  $value['identifier'] => $this->__get($primaryKey)
+                );
         $cleanCollection = new $key();
         $cleanCollection->fetch($search);
 

--- a/utils/routes/BaseRoute.php
+++ b/utils/routes/BaseRoute.php
@@ -91,10 +91,10 @@ class BaseRoute {
 
   protected function _try_fetching_model_dependencies($dependencies, $modelName, $identifier) {
     try {
-      $search = array('id' => $identifier);
-
-      // don't do any searching until we need to
+    	      // don't do any searching until we need to
       $dummyModel = new $modelName();
+      $primaryKey = $dummyModel->get_db_primary_key();
+      $search = array($primaryKey => $identifier);
       $modelAttributes = $dummyModel->get_attributes();
 
       // iterate through all of the dependencies, adding them to the search


### PR DESCRIPTION
we can't run tests yet, so here's my ghetto copy paste of Ae-api's tests not breaking

```
vagrant@vagrant-ubuntu-trusty-64:/mnt/tests$ phpunit
PHPUnit 4.8.6 by Sebastian Bergmann and contributors.

................................................................. 65 / 88 ( 73%)
.......................

Time: 1.01 minutes, Memory: 19.00Mb

OK (88 tests, 524 assertions)
```

This issue came up because the oAuth lib we are using has things set as primary keys that aren't 'id'

I should probably fix the base tests because ID is hardcoded in there for cleanup. 