### PR TITLE
A bunch of testing related things I need for Auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test: test-style test-unit
 
 .PHONY: test-unit
 test-unit:
-	cd test/ && ../vendor/bin/phpunit --debug
+	cd test/ && TESTMODE=true ../vendor/bin/phpunit --debug
 
 .PHONY: test-style
 test-style:

--- a/utils/config/sample-config.php
+++ b/utils/config/sample-config.php
@@ -1,0 +1,31 @@
+<?php
+
+// this allows us to require files rather easy
+define('API_BASE_PATH', realpath(__DIR__ . '/../src/api'));
+
+//version
+define('VERSION_PREFIX', 'v');
+define('VERSION_NUMBER', '1');
+define('VERSION', VERSION_PREFIX.VERSION_NUMBER);
+
+// setup our database constants
+define('DB_HOST', '127.0.0.1');
+define('DB_USERNAME', 'root');
+define('DB_PASSWORD', '12345');
+define('DB_DATABASE', 'auth');
+define('TEST_DB_DATABASE', 'testauth');
+define('TESTMODE', getenv('TESTMODE'));
+
+// allow us to debug at times
+define('API_DEBUG', true);
+
+
+define('AUTH_CONFIG_FAILED_LOGIN_ATTEMPTS', 50);
+define('AUTH_CONFIG_ACCOUNT_LOCKED_TIME', 20 * 60);  // 20 minutes
+define('AUTH_CONFIG_FAILED_LOGINS_WARNING', 35);
+define('AUTH_CONFIG_HASH_COST', 14);
+define('AUTH_PASSWORD_TOKEN_EXPIRATION_TIME', 60 * 60 * 24 * 3); // 3 days
+define('AUTH_SIGNUP_TOKEN_EXPIRATION_TIME', 60 * 60 * 24 * 3); // 3 days
+define('AUTH_DOMAIN', 'https://audienceengine.net');
+
+define('MANDRIL_API_KEY', 'XXXXXXXXXXXXXXXXXXXXXX');

--- a/utils/database.php
+++ b/utils/database.php
@@ -82,8 +82,13 @@ class Database implements DatabaseInterface {
 
     //throw errors, but not too many
     mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+    if (defined('TESTMODE')) {
+      $database = TEST_DB_DATABASE;
+    } else {
+      $database = DB_DATABASE;
+    }
 
-    self::$_mysql = new mysqli(DB_HOST, DB_USERNAME, DB_PASSWORD, DB_DATABASE);
+    self::$_mysql = new mysqli(DB_HOST, DB_USERNAME, DB_PASSWORD, $database);
     self::$_mysql->autocommit(false);
   }
 
@@ -522,5 +527,4 @@ class Database implements DatabaseInterface {
 
     return $results;
   }
-
 }

--- a/utils/router.php
+++ b/utils/router.php
@@ -145,7 +145,7 @@ class Router Implements RouterInterface {
       'post' => $_POST
     );
 
-    if ($request['api_version'] && $request['api_version'] !== VERSION){
+    if ($request['api_version'] !== VERSION) {
       self::_send_404();
     }
 

--- a/utils/tests/BaseEndpoint.php
+++ b/utils/tests/BaseEndpoint.php
@@ -1,9 +1,6 @@
 <?php
-
 abstract class BaseEndpoint extends PHPUnit_Extensions_Database_TestCase {
-
   const API_BASE_URL = 'http://auth.dev/' . VERSION . '/';
-
   protected $_guzzle = null;
   static private $_pdo = null;
   protected $_conn = null;
@@ -14,10 +11,10 @@ abstract class BaseEndpoint extends PHPUnit_Extensions_Database_TestCase {
     if (!$this->_conn) {
       if (!self::$_pdo) {
         self::$_pdo = new PDO('mysql:host=' . DB_HOST .';dbname=' .
-          DB_DATABASE , DB_USERNAME , DB_PASSWORD);
+         TEST_DB_DATABASE , DB_USERNAME , DB_PASSWORD);
       }
 
-      $this->_conn = $this->createDefaultDBConnection(self::$_pdo, DB_DATABASE);
+      $this->_conn = $this->createDefaultDBConnection(self::$_pdo, TEST_DB_DATABASE);
     }
 
     return $this->_conn;
@@ -141,10 +138,29 @@ abstract class BaseEndpoint extends PHPUnit_Extensions_Database_TestCase {
     }
   }
 
+  public function truncate($table){
+    $query = 'SET FOREIGN_KEY_CHECKS=0; truncate `' . $table . '`; SET FOREIGN_KEY_CHECKS=1;';
+    $this->_conn->getConnection()->exec($query);
+  }
+
   public function tearDown() {
     //always remove the dataset
     $dataset = $this->_data_set;
     $this->_db_remove_rows($dataset);
     parent::tearDown();
+  }
+
+  public function dashKeys($array, $arrayHolder = array()) {
+    $dashArray = !empty($arrayHolder) ? $arrayHolder : array();
+    foreach ($array as $key => $val) {
+      $newKey = str_replace('_', '-', $key);
+      if (!is_array($val)) {
+        $dashArray[$newKey] = $val;
+      } else {
+        $dashArray[$newKey] = $this->dashKeys($val);
+      }
+    }
+
+    return $dashArray;
   }
 }

--- a/utils/tests/BaseServiceTest.php
+++ b/utils/tests/BaseServiceTest.php
@@ -11,10 +11,10 @@ abstract class BaseServiceTest extends PHPUnit_Extensions_Database_TestCase {
     if (!$this->_conn) {
       if (!self::$_pdo) {
         self::$_pdo = new PDO('mysql:host=' . DB_HOST .';dbname=' .
-          DB_DATABASE , DB_USERNAME , DB_PASSWORD);
+          TEST_DB_DATABASE , DB_USERNAME , DB_PASSWORD);
       }
 
-      $this->_conn = $this->createDefaultDBConnection(self::$_pdo, DB_DATABASE);
+      $this->_conn = $this->createDefaultDBConnection(self::$_pdo, TEST_DB_DATABASE);
     }
 
     return $this->_conn;
@@ -90,6 +90,11 @@ abstract class BaseServiceTest extends PHPUnit_Extensions_Database_TestCase {
         throw new Exception('Specify table data to delete as an array.');
       }
     }
+  }
+
+  public function truncate($table){
+    $query = 'SET FOREIGN_KEY_CHECKS=0; truncate `' . $table . '`; SET FOREIGN_KEY_CHECKS=1;';
+    $this->_conn->getConnection()->exec($query);
   }
 
   public function tearDown() {


### PR DESCRIPTION
- use a test DB for testing api
  this might be handled in a ghetto fashion, but I need it very badly & I don't want to break anything else atm.

- Add dash keys method.  
 this was added to ae-api and not here. 

- Add truncate method. 
I'm now using PHPunit fixtures to clean up before and after tests instead of inside side tests. That way if they fail, the DB is still clean for the next one
https://phpunit.de/manual/current/en/fixtures.html
