### PR TITLE
Add documentation and reduce duplication

### DIFF
--- a/utils/tests/BaseEndpoint.php
+++ b/utils/tests/BaseEndpoint.php
@@ -80,29 +80,27 @@ abstract class BaseEndpoint extends PHPUnit_Extensions_Database_TestCase {
     }
   }
 
+  const HTTP_METHODS_REQUIRING_DATA = array('post', 'patch', 'put');
+
   protected function _fetch_results($url, $method, $data = null) {
     $method = strtolower($method);
     if (!method_exists($this->_guzzle, $method)) {
       throw new Exception('Invalid guzzle HTTP method specified');
     }
 
-    if ($method === 'post' || $method === 'patch' || $method === 'put') {
+    // Disable exceptions in order to simplify process of testing expected HTTP
+    // errors
+    $options = array( 'exceptions' => false );
+
+    if (in_array($method, self::HTTP_METHODS_REQUIRING_DATA)) {
       if (is_null($data)) {
         throw new Exception('Please specify valid data to ' . $method);
       }
 
-      $data = array(
-        'body' => $data,
-        'exceptions' => false
-      );
-
-      $response = $this->_guzzle->$method($url, $data);
-    } else {
-      $data = array(
-        'exceptions' => false
-      );
-      $response = $this->_guzzle->$method($url, $data);
+      $options['body'] = $data;
     }
+
+    $response = $this->_guzzle->$method($url, $options);
 
     return $response;
   }


### PR DESCRIPTION
Update test utility to avoid variable redefinition, document rationale
for Guzzle configuration, and avoid repetition.