### PR TITLE
Extend testing utility method

### DIFF
--- a/utils/tests/BaseEndpoint.php
+++ b/utils/tests/BaseEndpoint.php
@@ -82,7 +82,16 @@ abstract class BaseEndpoint extends PHPUnit_Extensions_Database_TestCase {
 
   const HTTP_METHODS_REQUIRING_DATA = array('post', 'patch', 'put');
 
-  protected function _fetch_results($url, $method, $data = null) {
+  /**
+   * Perform an HTTP request.
+   *
+   * @param string $url The location where the request should be sent
+   * @param string $method The HTTP verb to use
+   * @param array $options Optional modifiers for the request as supported by
+   *                       version 3 of the "Guzzle" library. Reference:
+   *                       https://guzzle3.readthedocs.org/http-client/client.html#request-options
+   */
+  protected function _fetch_results($url, $method, $options = array()) {
     $method = strtolower($method);
     if (!method_exists($this->_guzzle, $method)) {
       throw new Exception('Invalid guzzle HTTP method specified');
@@ -90,14 +99,12 @@ abstract class BaseEndpoint extends PHPUnit_Extensions_Database_TestCase {
 
     // Disable exceptions in order to simplify process of testing expected HTTP
     // errors
-    $options = array( 'exceptions' => false );
+    $options = array_merge( $options, array( 'exceptions' => false ));
 
     if (in_array($method, self::HTTP_METHODS_REQUIRING_DATA)) {
-      if (is_null($data)) {
+      if (!array_key_exists('body', $options)) {
         throw new Exception('Please specify valid data to ' . $method);
       }
-
-      $options['body'] = $data;
     }
 
     $response = $this->_guzzle->$method($url, $options);

--- a/utils/tests/BaseEndpoint.php
+++ b/utils/tests/BaseEndpoint.php
@@ -91,7 +91,7 @@ abstract class BaseEndpoint extends PHPUnit_Extensions_Database_TestCase {
    *                       version 3 of the "Guzzle" library. Reference:
    *                       https://guzzle3.readthedocs.org/http-client/client.html#request-options
    */
-  protected function _fetch_results($url, $method, $options = array()) {
+  private function _request($url, $method, $options = array()) {
     $method = strtolower($method);
     if (!method_exists($this->_guzzle, $method)) {
       throw new Exception('Invalid guzzle HTTP method specified');
@@ -107,9 +107,29 @@ abstract class BaseEndpoint extends PHPUnit_Extensions_Database_TestCase {
       }
     }
 
-    $response = $this->_guzzle->$method($url, $options);
+    return $this->_guzzle->$method($url, $options);
+  }
 
-    return $response;
+  protected function _fetch_results($url, $method, $data = null) {
+    $options = array();
+
+    if ($data !== null) {
+      $options['body'] = $data;
+    }
+
+    return $this->_request($url, $method, $options);
+  }
+
+  protected function _fetch_results_json($url, $method, $data = null) {
+    $options = array(
+      'headers' => array( 'Content-Type' => 'application/json' )
+    );
+
+    if ($data !== null) {
+      $options['body'] = json_encode($data);
+    }
+
+    return $this->_request($url, $method, $options);
   }
 
   protected function _db_get_by_id($table, $id) {


### PR DESCRIPTION
In order to more exhaustively test the behavior of the framework (e.g.
how it responds to various HTTP headers), the `_fetch_results` utility
function should allow for specification of additional details of the
request.

(This is in support of https://github.com/wfmu/ae-api/issues/220)